### PR TITLE
Add new group details for Bristol Stammtisch and Club 395

### DIFF
--- a/data/groups/bristol-stammtisch-german-conversation-group/details.json
+++ b/data/groups/bristol-stammtisch-german-conversation-group/details.json
@@ -1,0 +1,16 @@
+{
+  "name": "Bristol Stammtisch (German Conversation Group)",
+  "slug": "bristol-stammtisch-german-conversation-group",
+  "description": "German-speaking meet up in Bristol. A great chance to speak German or improve your German with friendly people. Ability ranges from novices to native speakers, so don't be shy, come along and enjoy a beer with us! We meet every other Tuesday evening, from 7.15pm in Zerodegrees.",
+  "details": "",
+  "links": [
+    {
+      "type": "Facebook",
+      "url": "https://www.facebook.com/groups/166765720572437/",
+      "text": "View on Facebook"
+    }
+  ],
+  "tags": [
+    "languages"
+  ]
+} 

--- a/data/groups/bristol-stammtisch-german-conversation-group/details.json
+++ b/data/groups/bristol-stammtisch-german-conversation-group/details.json
@@ -1,7 +1,7 @@
 {
   "name": "Bristol Stammtisch (German Conversation Group)",
   "slug": "bristol-stammtisch-german-conversation-group",
-  "description": "German-speaking meet up in Bristol. A great chance to speak German or improve your German with friendly people. Ability ranges from novices to native speakers, so don't be shy, come along and enjoy a beer with us! We meet every other Tuesday evening, from 7.15pm in Zerodegrees.",
+  "description": "German-speaking meetup in Bristol. A great chance to speak German or improve your German with friendly people. Ability ranges from novices to native speakers, so don't be shy, come along and enjoy a beer with us! We meet every other Tuesday evening, from 7.15pm in Zerodegrees.",
   "details": "",
   "links": [
     {

--- a/data/groups/club-395/details.json
+++ b/data/groups/club-395/details.json
@@ -1,0 +1,40 @@
+{
+    "name": "Club 395",
+    "slug": "club-395",
+    "description": "For all ages, introverts or not, come make friends, do art, craft anything you like, with different focuses every week, completely unpredictable but fun!",
+    "details": "A safe & diverse space in every possible way, to share your projects, your struggles, be truly yourself and have a creative sesh - whether its drawing, painting, crocheting, fashion, digital design, photography, brainstorming, or join us and play Dungeons and Dragons, or discuss anime & manga 🌊  Please donate what you can or buy drinks if you can to support.",
+    "links": [
+      {
+        "type": "Instagram",
+        "url": "https://www.instagram.com/club395_"
+      }
+    ],
+    "tags": [
+      "creative"
+    ],
+    "events": [
+      {
+        "time": {
+          "frequency": "Weekly on Tuesdays",
+          "weekday": "Tuesday",
+          "start": "Jan 1, 1970 19:00",
+          "end": "Jan 1, 1970 22:00",
+          "details": ""
+        },
+        "location": {
+          "address": "Unit 4, Old Malt House, Little Ann St, St Jude's, BS2 9EB",
+          "latitude": "51.4595869",
+          "longitude": "-2.5784456",
+          "googleMapsLink": "https://maps.app.goo.gl/xJTcFvpGtnPEbhENA",
+          "details": ""
+        },
+        "cost": {
+          "sessionPrice": 0,
+          "details": "Please donate what you can or buy drinks if you can to support. Donations on headfirst 😇"
+        },
+        "booking": {
+          "required": "Not required"
+        }
+      }
+    ]
+  } 

--- a/data/groups/club-395/details.json
+++ b/data/groups/club-395/details.json
@@ -2,7 +2,7 @@
     "name": "Club 395",
     "slug": "club-395",
     "description": "For all ages, introverts or not, come make friends, do art, craft anything you like, with different focuses every week, completely unpredictable but fun!",
-    "details": "A safe & diverse space in every possible way, to share your projects, your struggles, be truly yourself and have a creative sesh - whether its drawing, painting, crocheting, fashion, digital design, photography, brainstorming, or join us and play Dungeons and Dragons, or discuss anime & manga 🌊  Please donate what you can or buy drinks if you can to support.",
+    "details": "A safe & diverse space in every possible way, to share your projects, your struggles, be truly yourself and have a creative sesh - whether it's drawing, painting, crocheting, fashion, digital design, photography, brainstorming, or join us and play Dungeons and Dragons, or discuss anime & manga 🌊  Please donate what you can or buy drinks if you can to support.",
     "links": [
       {
         "type": "Instagram",
@@ -30,7 +30,7 @@
         },
         "cost": {
           "sessionPrice": 0,
-          "details": "Please donate what you can or buy drinks if you can to support. Donations on headfirst 😇"
+          "details": "Please donate what you can or buy drinks if you can to support. Donations on Headfirst 😇"
         },
         "booking": {
           "required": "Not required"


### PR DESCRIPTION
- Introduced "Bristol Stammtisch (German Conversation Group)" with description, links, and tags.
- Added "Club 395" featuring a creative space description, event details, location, and social media links.