### PR TITLE
Anime club: Remove Meetup links, no longer used

### DIFF
--- a/data/groups/the-anime-club/details.json
+++ b/data/groups/the-anime-club/details.json
@@ -1,17 +1,13 @@
 {
     "name": "The Anime Club - Bristol & Beyond",
     "slug": "the-anime-club",
-    "description": "A community of adult anime fans that meet up in Bristol, organised on Discord. We have in-person meetups every other Friday, as well as other events including watch parties, karaoke, and attending conventions. Over 18s only. See the Meetup page for details. Note that attendance numbers on both Meetup and Discord are innacurate, as most regulars don't mark their attendance every time.",
+    "description": "A community of adult anime fans that meet up in Bristol, organised on Discord. We have in-person meetups every other Friday, as well as other events including watch parties, karaoke, and attending conventions. Over 18s only. Join the Discord for details. Note that attendance numbers are inaccurate, as most regulars don't mark their attendance every time.",
     "details": "",
     "tags": ["anime", "film", "animation"],
     "links": [
         {
             "type": "Discord",
             "url": "https://discord.gg/FNwe9pBDha"
-        },
-        {
-            "type": "Meetup",
-            "url": "https://www.meetup.com/meetup-group-lyqtckmt/"
         }
     ],
     "events": [
@@ -26,9 +22,9 @@
             },
             "booking": {
                 "required": "Not required",
-                "details": "Join the Meetup group or Discord server for event details and locations"
+                "details": "Join the Discord server for event details and locations"
             },
-            "locationURL": "https://www.meetup.com/meetup-group-lyqtckmt/",
+            "locationURL": "https://discord.gg/FNwe9pBDha",
             "cost": {
                 "sessionPrice": 0
             }

--- a/data/groups/the-anime-club/details.json
+++ b/data/groups/the-anime-club/details.json
@@ -1,7 +1,7 @@
 {
     "name": "The Anime Club - Bristol & Beyond",
     "slug": "the-anime-club",
-    "description": "A community of adult anime fans that meet up in Bristol, organised on Discord. We have in-person meetups every other Friday, as well as other events including watch parties, karaoke, and attending conventions. Over 18s only. Join the Discord for details. Note that attendance numbers are inaccurate, as most regulars don't mark their attendance every time.",
+    "description": "A community of adult anime fans that meet up in Bristol, organised on Discord. We have in-person meetups every other Friday, as well as other events including watch parties, karaoke, and attending conventions. Over 18s only. Join the Discord for details.",
     "details": "",
     "tags": ["anime", "film", "animation"],
     "links": [


### PR DESCRIPTION
Unfortunately we no longer use Meetup because of the increasing fees. However we don't have much need of it now that our entry in Bristol Social is ranking really well for 'bristol anime meetup'!